### PR TITLE
Avoid FloatingDecimal rounding

### DIFF
--- a/src/Transformation_Map/Transformation_Map.map
+++ b/src/Transformation_Map/Transformation_Map.map
@@ -33,7 +33,7 @@
                 <expression>
                     <input path="$Item/Price" var="Price"/>
                     <output path="Cost" var="Cost"/>
-                    <code lang="xpath">$Price * 1.6</code>
+                    <code lang="xpath"> fn:round-half-to-even( (xs:decimal($Price) * xs:decimal(1.6)),  2 )</code>
                 </expression>
                 <move>
                     <input path="$Item/Quantity"/>
@@ -55,7 +55,7 @@
             <expression>
                 <input path="$Invoice/." var="Invoice1"/>
                 <output path="Amount/mixed" var="mixed"/>
-                <code lang="xpath">fn:sum($Invoice1/Item/(Price*Quantity)) * 1.6</code>
+                <code lang="xpath"> fn:round-half-to-even(  (fn:sum($Invoice1/Item/(Price*Quantity)) * 1.6 ), 2 )</code>
             </expression>
             <move>
                 <input path="$Invoice/Currency"/>


### PR DESCRIPTION
By using a untyped literal in the Custom XPath calculations were getting
promoted to float precision.
Since target is a decimal representing currency amount, the current
outputs like "0.32000000000000006" are not appropriate and introduce
overheads using float precision. The tutorial should demonstrate the use
of explicit xs: type casting and XPath functions for rounding, so that
the output is like "0.32".
